### PR TITLE
Update dependencies to pyquil 2.26.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,6 @@ stages:
     QUILC_URL: "tcp://quilc:5555"
   before_script:
     - make requirements
-    - pip uninstall -y pyquil  # these steps are temporary until Quil-T GA
-    - pip install git+https://github.com/rigetti/pyquil.git@quilt-demo#egg=pyquil
   script:
     - make test
 

--- a/notebooks/quilt/QuiltMaxCutQAOA.ipynb
+++ b/notebooks/quilt/QuiltMaxCutQAOA.ipynb
@@ -290,7 +290,7 @@
    "source": [
     "## Run landscape **with** global fencing disabled\n",
     "\n",
-    "Second, we run and display the landscape produced with global fencing disabled. Results on QPU show visually the improvement in fidelity that is gained by this parallel execution of 2Q gates, with deeper minima and a more feature-rich expectation value landscape."
+    "Second, we run and display the landscape produced with global fencing disabled. Results on QPU show visually the improvement in fidelity that is gained by this parallel execution of 2Q gates."
    ]
   },
   {
@@ -345,7 +345,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/quilt/QuiltMaxCutQAOA.ipynb
+++ b/notebooks/quilt/QuiltMaxCutQAOA.ipynb
@@ -142,7 +142,7 @@
     "\n",
     "Quil-T extends Quil programs with the concept of *calibrations*. A calibration defines the pulse-level control sequence for a specific native instruction at a specific site. For example, the Quil operation \"CZ 31 32\" will have a calibration for that gate (CZ) at that site (the edge 31-32), written in Quil-T as \"DEFCAL CZ 31 32\".\n",
     "\n",
-    "To disable global fencing on CZ gates, we must generate new calibrations using Quil-T that modify the pulse-level control sequence to replace global fencing directives (\"FENCE_ALL\") with fencing local to just the 2 qubits being operated upon (\"FENCE \\<q0\\> \\<q1\\>\"). We achieve this by first retreiving the current calibrations as updated at the last retune, calling `qc.compiler.get_calibration_program()`, and modify them in the stated way."
+    "To disable global fencing on CZ gates, we must generate new calibrations using Quil-T that modify the pulse-level control sequence to replace global fencing directives (\"FENCE\") with fencing local to just the 2 qubits being operated upon (\"FENCE \\<q0\\> \\<q1\\>\"). We achieve this by first retreiving the current calibrations as updated at the last retune, calling `qc.compiler.get_calibration_program()`, and modify them in the stated way."
    ]
   },
   {
@@ -290,7 +290,7 @@
    "source": [
     "## Run landscape **with** global fencing disabled\n",
     "\n",
-    "Second, we run and display the landscape produced with global fencing disabled. Results on QPU show visually the improvement in fidelity that is gained by this parallel execution of 2Q gates."
+    "Second, we run and display the landscape produced with global fencing disabled. Results on QPU show visually the improvement in fidelity that is gained by this parallel execution of 2Q gates, with deeper minima and a more feature-rich expectation value landscape."
    ]
   },
   {
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To see what the native program looks like when fencing is disabled, you can print it out. When this is run on QPU, you will see \"DEFCAL\" instructions that include \"FENCE\" directives that only isolate the qubit pair being operated upon, whereas the default calibration contains \"FENCE_ALL\" directives."
+    "To see what the native program looks like when fencing is disabled, you can print it out. When this is run on QPU, you will see \"DEFCAL\" instructions that include \"FENCE\" directives that only isolate the qubit pair being operated upon."
    ]
   },
   {
@@ -345,7 +345,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ jupyter >= 1.0.0
 matplotlib >= 3.3.0
 networkx >= 2.5
 numpy >= 1.19.0
-pyquil >= 2.25.0
+pyquil >= 2.26.0
 tqdm >= 4.53.0


### PR DESCRIPTION
Update requirements and CI integration to use Quil-T support release of pyquil.